### PR TITLE
Add subject cardinality control to Prometheus middleware

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,12 +121,14 @@ Each package implements a specific messaging pattern with full type safety:
 
 #### Prometheus Middleware Subject Cardinality Control (#25)
 
-- `contrib/prom` now supports normalizing the `subject` label via a `SubjectMapper`
+- `contrib/prom` normalizes the `subject` label via a `SubjectMapper`
 - New option `MiddlewareSubjectMapper(SubjectMapper)` installs a `func(string) string`
 - Helpers: `SubjectDepth(n)` keeps first `n` dot-separated tokens (n<=0 collapses to "")
 - Helpers: `SubjectConstant(v)` yields a fixed value (`SubjectConstant("")` effectively disables the subject dimension)
-- Backward compatible: default behavior (no mapper) preserves the full subject
+- **Default changed (v0.25.0)**: `SubjectDepth(DefaultSubjectDepth)` with `DefaultSubjectDepth = 3`; pre-0.25 behavior restored via `MiddlewareSubjectMapper(nil)`
+- `subjectMapperSet` sentinel in `params` distinguishes "not configured" (apply default) from "explicitly nil" (pass-through)
 - Mapped subject computed once per message and threaded through `ackableWrapper`, so ack/nak/term counters match processed/latency/in_flight labels
+- Breaking change documented in UPGRADING.md under v0.24.x → v0.25.0
 - Fixes OOM caused by unbounded label cardinality on JetStream subjects with dynamic tokens
 
 #### Prometheus Middleware Metadatable Interface Fix
@@ -251,6 +253,7 @@ Each package implements a specific messaging pattern with full type safety:
 
 ### Changelog
 
+- 2026-04-13: v0.25.0 — contrib/prom default subject mapper is now `SubjectDepth(3)` (breaking: restore with `MiddlewareSubjectMapper(nil)`); see UPGRADING.md (#25)
 - 2026-04-13: contrib/prom: `SubjectMapper` + `SubjectDepth`/`SubjectConstant` helpers to bound subject label cardinality (#25)
 - 2026-02-10: Content-Encoding compression layer: zstd + s2 support in codec, publisher, requester, bucket
 - 2026-02-09: Replaced Submitter + ErrorHandler with Dispatcher interface; deleted `subm.go` and `err.go`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,16 @@ Each package implements a specific messaging pattern with full type safety:
 
 ### Notes
 
+#### Prometheus Middleware Subject Cardinality Control (#25)
+
+- `contrib/prom` now supports normalizing the `subject` label via a `SubjectMapper`
+- New option `MiddlewareSubjectMapper(SubjectMapper)` installs a `func(string) string`
+- Helpers: `SubjectDepth(n)` keeps first `n` dot-separated tokens (n<=0 collapses to "")
+- Helpers: `SubjectConstant(v)` yields a fixed value (`SubjectConstant("")` effectively disables the subject dimension)
+- Backward compatible: default behavior (no mapper) preserves the full subject
+- Mapped subject computed once per message and threaded through `ackableWrapper`, so ack/nak/term counters match processed/latency/in_flight labels
+- Fixes OOM caused by unbounded label cardinality on JetStream subjects with dynamic tokens
+
 #### Prometheus Middleware Metadatable Interface Fix
 
 - Fixed prometheus middleware wrapper losing Metadatable interface from wrapped messages
@@ -241,6 +251,7 @@ Each package implements a specific messaging pattern with full type safety:
 
 ### Changelog
 
+- 2026-04-13: contrib/prom: `SubjectMapper` + `SubjectDepth`/`SubjectConstant` helpers to bound subject label cardinality (#25)
 - 2026-02-10: Content-Encoding compression layer: zstd + s2 support in codec, publisher, requester, bucket
 - 2026-02-09: Replaced Submitter + ErrorHandler with Dispatcher interface; deleted `subm.go` and `err.go`
 - 2026-02-09: Moved `Unsubscriber` and `Subscription` interfaces from root to `transport/` package; deleted `interfaces.go`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,64 @@
 # Upgrading
 
+## v0.24.x → v0.25.0
+
+### Summary
+
+`contrib/prom` now truncates the `subject` label to the first three
+dot-separated tokens by default, bounding Prometheus metric cardinality on
+JetStream consumers whose subjects contain dynamic tails (tenant IDs, entity
+IDs, sequence numbers). Prior releases used the raw subject, which could
+exhaust memory within minutes on high-fanout streams (#25).
+
+This is a label-schema break: any dashboard, alert, or recording rule keyed
+on the full subject will see a truncated value after the upgrade. Existing
+series at the old cardinality remain in the TSDB until they age out — queries
+that join across the cut-over point should use regex matching on the label.
+
+### Action required
+
+Callers who need the previous behavior must restore it explicitly:
+
+```go
+// Pass-through: use the raw subject as-is (pre-0.25 default).
+// WARNING: susceptible to the unbounded-cardinality OOM described in #25.
+_ = prom.Middleware(
+    prom.MiddlewareSubjectMapper(nil),
+)
+```
+
+Callers who want a different bound can pick their own:
+
+```go
+// Keep the first 5 tokens instead of the default 3.
+_ = prom.Middleware(
+    prom.MiddlewareSubjectMapper(prom.SubjectDepth(5)),
+)
+
+// Or collapse the subject dimension entirely.
+_ = prom.Middleware(
+    prom.MiddlewareSubjectMapper(prom.SubjectConstant("")),
+)
+
+// Or a custom mapping function.
+_ = prom.Middleware(
+    prom.MiddlewareSubjectMapper(func(s string) string {
+        // ... e.g. strip UUIDs, apply per-stream rules, etc.
+        return s
+    }),
+)
+```
+
+### Dashboards & alerts
+
+Subject values in recorded metrics will change from e.g.
+`orders.v1.created.tenant-42.entity-abc` to `orders.v1.created`. Update any
+PromQL selectors that pin the full subject. Most dashboards aggregating with
+`sum by (subject) (...)` will keep working but will show fewer, coarser
+series.
+
+---
+
 ## v0.22.x → v0.23.0
 
 ### Summary

--- a/contrib/prom/middleware.go
+++ b/contrib/prom/middleware.go
@@ -47,14 +47,22 @@ func SubjectConstant(value string) SubjectMapper {
 	}
 }
 
+// DefaultSubjectDepth is the depth used by the default SubjectMapper. It keeps
+// the first three dot-separated tokens of each subject, which is a reasonable
+// compromise between observability and cardinality: it retains enough prefix
+// to distinguish logical streams (e.g. "orders.v1.created") while discarding
+// dynamic tails (tenant IDs, entity IDs, sequence numbers).
+const DefaultSubjectDepth = 3
+
 // Option configures Prometheus middleware
 type Option func(*params)
 
 type params struct {
-	namespace     string
-	subsystem     string
-	registerer    prometheus.Registerer
-	subjectMapper SubjectMapper
+	namespace        string
+	subsystem        string
+	registerer       prometheus.Registerer
+	subjectMapper    SubjectMapper
+	subjectMapperSet bool
 }
 
 // MiddlewareNamespace sets the Prometheus namespace for metrics
@@ -82,11 +90,14 @@ func MiddlewareRegisterer(registerer prometheus.Registerer) Option {
 // before they are used as the value of the "subject" label. Use this to
 // prevent unbounded metric cardinality when subjects contain dynamic segments.
 //
-// Without this option, the full subject is used as-is, which matches the
-// default behavior of prior releases.
+// If this option is not supplied, the middleware uses SubjectDepth(DefaultSubjectDepth)
+// as a safe default. Pass SubjectConstant(...) or a custom mapper (including a
+// pass-through `func(s string) string { return s }`) to override. Passing nil
+// explicitly also yields pass-through behavior.
 func MiddlewareSubjectMapper(mapper SubjectMapper) Option {
 	return func(p *params) {
 		p.subjectMapper = mapper
+		p.subjectMapperSet = true
 	}
 }
 
@@ -94,13 +105,15 @@ func MiddlewareSubjectMapper(mapper SubjectMapper) Option {
 func Middleware(opts ...Option) peanats.MsgMiddleware {
 	// Apply default configuration
 	p := params{
-		namespace:     "peanats",
-		subsystem:     "",
-		registerer:    prometheus.DefaultRegisterer,
-		subjectMapper: nil,
+		namespace:  "peanats",
+		subsystem:  "",
+		registerer: prometheus.DefaultRegisterer,
 	}
 	for _, opt := range opts {
 		opt(&p)
+	}
+	if !p.subjectMapperSet {
+		p.subjectMapper = SubjectDepth(DefaultSubjectDepth)
 	}
 
 	// Total number of messages processed by subject and status

--- a/contrib/prom/middleware.go
+++ b/contrib/prom/middleware.go
@@ -10,13 +10,51 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
+// SubjectMapper transforms a NATS subject into a label value. It is used to
+// normalize subjects with dynamic segments (e.g. entity IDs) into a bounded
+// set of label values, preventing unbounded Prometheus metric cardinality.
+type SubjectMapper func(subject string) string
+
+// SubjectDepth returns a SubjectMapper that truncates subjects to the first n
+// dot-separated tokens. For example, SubjectDepth(3) maps "a.b.c.d.e" to "a.b.c".
+// A non-positive n returns an empty string for all subjects, effectively
+// collapsing cardinality to a single bucket.
+func SubjectDepth(n int) SubjectMapper {
+	return func(subject string) string {
+		if n <= 0 {
+			return ""
+		}
+		depth := 0
+		for i := 0; i < len(subject); i++ {
+			if subject[i] == '.' {
+				depth++
+				if depth == n {
+					return subject[:i]
+				}
+			}
+		}
+		return subject
+	}
+}
+
+// SubjectConstant returns a SubjectMapper that always yields the given value,
+// regardless of the input subject. Useful to collapse a high-cardinality
+// stream into a single label value or to effectively disable the subject
+// label by passing "".
+func SubjectConstant(value string) SubjectMapper {
+	return func(string) string {
+		return value
+	}
+}
+
 // Option configures Prometheus middleware
 type Option func(*params)
 
 type params struct {
-	namespace  string
-	subsystem  string
-	registerer prometheus.Registerer
+	namespace     string
+	subsystem     string
+	registerer    prometheus.Registerer
+	subjectMapper SubjectMapper
 }
 
 // MiddlewareNamespace sets the Prometheus namespace for metrics
@@ -40,13 +78,26 @@ func MiddlewareRegisterer(registerer prometheus.Registerer) Option {
 	}
 }
 
+// MiddlewareSubjectMapper installs a SubjectMapper that normalizes subjects
+// before they are used as the value of the "subject" label. Use this to
+// prevent unbounded metric cardinality when subjects contain dynamic segments.
+//
+// Without this option, the full subject is used as-is, which matches the
+// default behavior of prior releases.
+func MiddlewareSubjectMapper(mapper SubjectMapper) Option {
+	return func(p *params) {
+		p.subjectMapper = mapper
+	}
+}
+
 // Middleware creates a peanats.MsgMiddleware that records message processing metrics
 func Middleware(opts ...Option) peanats.MsgMiddleware {
 	// Apply default configuration
 	p := params{
-		namespace:  "peanats",
-		subsystem:  "",
-		registerer: prometheus.DefaultRegisterer,
+		namespace:     "peanats",
+		subsystem:     "",
+		registerer:    prometheus.DefaultRegisterer,
+		subjectMapper: nil,
 	}
 	for _, opt := range opts {
 		opt(&p)
@@ -88,11 +139,15 @@ func Middleware(opts ...Option) peanats.MsgMiddleware {
 	return func(next peanats.MsgHandler) peanats.MsgHandler {
 		return peanats.MsgHandlerFunc(func(ctx context.Context, msg peanats.Msg) error {
 			subject := msg.Subject()
+			if p.subjectMapper != nil {
+				subject = p.subjectMapper(subject)
+			}
 
 			// Wrap ackable messages to track acknowledgment metrics
 			if _, ok := msg.(peanats.Ackable); ok {
 				msg = &ackableWrapper{
 					Msg:     msg,
+					subject: subject,
 					counter: msgsAcked,
 				}
 			}
@@ -125,42 +180,43 @@ func Middleware(opts ...Option) peanats.MsgMiddleware {
 // ackableWrapper wraps an Ackable message to track acknowledgment metrics
 type ackableWrapper struct {
 	peanats.Msg
+	subject string
 	counter *prometheus.CounterVec
 }
 
 func (a *ackableWrapper) Ack(ctx context.Context) error {
 	err := a.Msg.(peanats.Ackable).Ack(ctx)
-	a.counter.WithLabelValues(a.Subject(), "ack").Inc()
+	a.counter.WithLabelValues(a.subject, "ack").Inc()
 	return err
 }
 
 func (a *ackableWrapper) Nak(ctx context.Context) error {
 	err := a.Msg.(peanats.Ackable).Nak(ctx)
-	a.counter.WithLabelValues(a.Subject(), "nak").Inc()
+	a.counter.WithLabelValues(a.subject, "nak").Inc()
 	return err
 }
 
 func (a *ackableWrapper) NackWithDelay(ctx context.Context, delay time.Duration) error {
 	err := a.Msg.(peanats.Ackable).NackWithDelay(ctx, delay)
-	a.counter.WithLabelValues(a.Subject(), "nak").Inc()
+	a.counter.WithLabelValues(a.subject, "nak").Inc()
 	return err
 }
 
 func (a *ackableWrapper) Term(ctx context.Context) error {
 	err := a.Msg.(peanats.Ackable).Term(ctx)
-	a.counter.WithLabelValues(a.Subject(), "term").Inc()
+	a.counter.WithLabelValues(a.subject, "term").Inc()
 	return err
 }
 
 func (a *ackableWrapper) TermWithReason(ctx context.Context, reason string) error {
 	err := a.Msg.(peanats.Ackable).TermWithReason(ctx, reason)
-	a.counter.WithLabelValues(a.Subject(), "term").Inc()
+	a.counter.WithLabelValues(a.subject, "term").Inc()
 	return err
 }
 
 func (a *ackableWrapper) InProgress(ctx context.Context) error {
 	err := a.Msg.(peanats.Ackable).InProgress(ctx)
-	a.counter.WithLabelValues(a.Subject(), "in_progress").Inc()
+	a.counter.WithLabelValues(a.subject, "in_progress").Inc()
 	return err
 }
 

--- a/contrib/prom/middleware_test.go
+++ b/contrib/prom/middleware_test.go
@@ -567,6 +567,65 @@ peanats_processed_total{status="success",subject=""} 2
 	assert.NoError(t, compareErr)
 }
 
+func TestPrometheusMiddleware_DefaultSubjectMapper(t *testing.T) {
+	// The default middleware (no MiddlewareSubjectMapper option) should apply
+	// SubjectDepth(DefaultSubjectDepth) to bound cardinality out of the box.
+	registry := prometheus.NewRegistry()
+
+	// Subject with dynamic tail tokens beyond the default depth.
+	mockMsg := peanatsmock.NewMsg(t)
+	mockMsg.EXPECT().Subject().Return("orders.v1.created.tenant-42.entity-abc").Maybe()
+	mockMsg.EXPECT().Data().Return([]byte("data")).Maybe()
+	mockMsg.EXPECT().Header().Return(peanats.Header{}).Maybe()
+
+	middleware := Middleware(MiddlewareRegisterer(registry))
+
+	handler := peanats.MsgHandlerFunc(func(ctx context.Context, msg peanats.Msg) error {
+		return nil
+	})
+	wrapped := middleware(handler)
+	require.NoError(t, wrapped.HandleMsg(context.Background(), mockMsg))
+
+	// Expect the subject to be truncated to the first DefaultSubjectDepth tokens.
+	expected := `
+# HELP peanats_processed_total Total number of messages processed
+# TYPE peanats_processed_total counter
+peanats_processed_total{status="success",subject="orders.v1.created"} 1
+`
+	compareErr := testutil.GatherAndCompare(registry, strings.NewReader(expected), "peanats_processed_total")
+	assert.NoError(t, compareErr)
+}
+
+func TestPrometheusMiddleware_ExplicitNilMapperDisablesDefault(t *testing.T) {
+	// Passing MiddlewareSubjectMapper(nil) explicitly should disable the
+	// default and yield pass-through behavior (raw subject).
+	registry := prometheus.NewRegistry()
+
+	mockMsg := peanatsmock.NewMsg(t)
+	mockMsg.EXPECT().Subject().Return("orders.v1.created.tenant-42.entity-abc").Maybe()
+	mockMsg.EXPECT().Data().Return([]byte("data")).Maybe()
+	mockMsg.EXPECT().Header().Return(peanats.Header{}).Maybe()
+
+	middleware := Middleware(
+		MiddlewareRegisterer(registry),
+		MiddlewareSubjectMapper(nil),
+	)
+
+	handler := peanats.MsgHandlerFunc(func(ctx context.Context, msg peanats.Msg) error {
+		return nil
+	})
+	wrapped := middleware(handler)
+	require.NoError(t, wrapped.HandleMsg(context.Background(), mockMsg))
+
+	expected := `
+# HELP peanats_processed_total Total number of messages processed
+# TYPE peanats_processed_total counter
+peanats_processed_total{status="success",subject="orders.v1.created.tenant-42.entity-abc"} 1
+`
+	compareErr := testutil.GatherAndCompare(registry, strings.NewReader(expected), "peanats_processed_total")
+	assert.NoError(t, compareErr)
+}
+
 func TestPrometheusMiddleware_SubjectMapper_AppliedToAckCounters(t *testing.T) {
 	// Create a new registry for this test
 	registry := prometheus.NewRegistry()

--- a/contrib/prom/middleware_test.go
+++ b/contrib/prom/middleware_test.go
@@ -455,3 +455,153 @@ peanats_processed_total{status="success",subject="test.subject"} 1
 	compareErr := testutil.GatherAndCompare(registry, strings.NewReader(expected), "peanats_processed_total")
 	assert.NoError(t, compareErr, "Processed counter should be incremented")
 }
+
+func TestSubjectDepth(t *testing.T) {
+	tests := []struct {
+		name    string
+		depth   int
+		subject string
+		want    string
+	}{
+		{"depth 1", 1, "a.b.c.d", "a"},
+		{"depth 2", 2, "a.b.c.d", "a.b"},
+		{"depth 3", 3, "a.b.c.d", "a.b.c"},
+		{"depth equal to tokens", 4, "a.b.c.d", "a.b.c.d"},
+		{"depth exceeds tokens", 10, "a.b.c.d", "a.b.c.d"},
+		{"single token", 2, "a", "a"},
+		{"empty subject", 2, "", ""},
+		{"zero depth collapses", 0, "a.b.c", ""},
+		{"negative depth collapses", -1, "a.b.c", ""},
+		{"real jetstream subject", 5, "up.eu.monitoring.v1beta7.checkexecutionrequested.tenant-42.entity-abc", "up.eu.monitoring.v1beta7.checkexecutionrequested"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := SubjectDepth(tt.depth)(tt.subject)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSubjectConstant(t *testing.T) {
+	assert.Equal(t, "fixed", SubjectConstant("fixed")("a.b.c"))
+	assert.Equal(t, "", SubjectConstant("")("a.b.c"))
+	assert.Equal(t, "", SubjectConstant("")(""))
+}
+
+func TestPrometheusMiddleware_SubjectMapper_CollapsesCardinality(t *testing.T) {
+	// Create a new registry for this test
+	registry := prometheus.NewRegistry()
+
+	// Two messages with different full subjects that share a common prefix.
+	msg1 := peanatsmock.NewMsg(t)
+	msg1.EXPECT().Subject().Return("up.eu.monitoring.v1.entity-abc").Maybe()
+	msg1.EXPECT().Data().Return([]byte("data")).Maybe()
+	msg1.EXPECT().Header().Return(peanats.Header{}).Maybe()
+
+	msg2 := peanatsmock.NewMsg(t)
+	msg2.EXPECT().Subject().Return("up.eu.monitoring.v1.entity-xyz").Maybe()
+	msg2.EXPECT().Data().Return([]byte("data")).Maybe()
+	msg2.EXPECT().Header().Return(peanats.Header{}).Maybe()
+
+	// Truncate to 4 tokens so both messages collapse to the same label value.
+	middleware := Middleware(
+		MiddlewareRegisterer(registry),
+		MiddlewareSubjectMapper(SubjectDepth(4)),
+	)
+
+	handler := peanats.MsgHandlerFunc(func(ctx context.Context, msg peanats.Msg) error {
+		return nil
+	})
+	wrapped := middleware(handler)
+
+	require.NoError(t, wrapped.HandleMsg(context.Background(), msg1))
+	require.NoError(t, wrapped.HandleMsg(context.Background(), msg2))
+
+	// Both messages should be counted under the truncated subject.
+	expected := `
+# HELP peanats_processed_total Total number of messages processed
+# TYPE peanats_processed_total counter
+peanats_processed_total{status="success",subject="up.eu.monitoring.v1"} 2
+`
+	compareErr := testutil.GatherAndCompare(registry, strings.NewReader(expected), "peanats_processed_total")
+	assert.NoError(t, compareErr)
+}
+
+func TestPrometheusMiddleware_SubjectMapper_ConstantEmpty(t *testing.T) {
+	// Create a new registry for this test
+	registry := prometheus.NewRegistry()
+
+	// Two messages with completely unrelated subjects.
+	msg1 := peanatsmock.NewMsg(t)
+	msg1.EXPECT().Subject().Return("foo.bar").Maybe()
+	msg1.EXPECT().Data().Return([]byte("data")).Maybe()
+	msg1.EXPECT().Header().Return(peanats.Header{}).Maybe()
+
+	msg2 := peanatsmock.NewMsg(t)
+	msg2.EXPECT().Subject().Return("baz.qux.quux").Maybe()
+	msg2.EXPECT().Data().Return([]byte("data")).Maybe()
+	msg2.EXPECT().Header().Return(peanats.Header{}).Maybe()
+
+	// Collapse every subject to an empty label — effectively disables the
+	// subject dimension for cardinality purposes.
+	middleware := Middleware(
+		MiddlewareRegisterer(registry),
+		MiddlewareSubjectMapper(SubjectConstant("")),
+	)
+
+	handler := peanats.MsgHandlerFunc(func(ctx context.Context, msg peanats.Msg) error {
+		return nil
+	})
+	wrapped := middleware(handler)
+
+	require.NoError(t, wrapped.HandleMsg(context.Background(), msg1))
+	require.NoError(t, wrapped.HandleMsg(context.Background(), msg2))
+
+	expected := `
+# HELP peanats_processed_total Total number of messages processed
+# TYPE peanats_processed_total counter
+peanats_processed_total{status="success",subject=""} 2
+`
+	compareErr := testutil.GatherAndCompare(registry, strings.NewReader(expected), "peanats_processed_total")
+	assert.NoError(t, compareErr)
+}
+
+func TestPrometheusMiddleware_SubjectMapper_AppliedToAckCounters(t *testing.T) {
+	// Create a new registry for this test
+	registry := prometheus.NewRegistry()
+
+	// Ackable message with a dynamic subject segment.
+	mockMsg := peanatsmock.NewMsgJetstream(t)
+	mockMsg.EXPECT().Subject().Return("a.b.c.entity-42").Maybe()
+	mockMsg.EXPECT().Data().Return([]byte("data")).Maybe()
+	mockMsg.EXPECT().Header().Return(peanats.Header{}).Maybe()
+	mockMsg.EXPECT().Ack(context.Background()).Return(nil).Once()
+
+	// Depth-2 truncation.
+	middleware := Middleware(
+		MiddlewareRegisterer(registry),
+		MiddlewareSubjectMapper(SubjectDepth(2)),
+	)
+
+	handler := peanats.MsgHandlerFunc(func(ctx context.Context, msg peanats.Msg) error {
+		ackable, ok := msg.(peanats.Ackable)
+		require.True(t, ok)
+		return ackable.Ack(ctx)
+	})
+	wrapped := middleware(handler)
+	require.NoError(t, wrapped.HandleMsg(context.Background(), mockMsg))
+
+	// Both processed_total and acked_total should carry the truncated subject,
+	// not the raw one.
+	expected := `
+# HELP peanats_acked_total Total number of message acknowledgments
+# TYPE peanats_acked_total counter
+peanats_acked_total{subject="a.b",type="ack"} 1
+# HELP peanats_processed_total Total number of messages processed
+# TYPE peanats_processed_total counter
+peanats_processed_total{status="success",subject="a.b"} 1
+`
+	compareErr := testutil.GatherAndCompare(registry, strings.NewReader(expected), "peanats_acked_total", "peanats_processed_total")
+	assert.NoError(t, compareErr)
+}


### PR DESCRIPTION
## Summary

This PR adds configurable subject label normalization to the Prometheus middleware in `contrib/prom` to prevent unbounded metric cardinality on JetStream consumers with dynamic subject segments (tenant IDs, entity IDs, etc.).

## Key Changes

- **New `SubjectMapper` type**: A function type `func(subject string) string` that transforms subjects before they become label values
- **Helper functions**:
  - `SubjectDepth(n)`: Truncates subjects to the first n dot-separated tokens (e.g., `SubjectDepth(3)` maps `"a.b.c.d.e"` to `"a.b.c"`)
  - `SubjectConstant(value)`: Returns a fixed value for all subjects, useful for collapsing cardinality or disabling the subject dimension entirely
- **New middleware option**: `MiddlewareSubjectMapper(mapper SubjectMapper)` to install custom subject normalization
- **Default behavior change**: Middleware now applies `SubjectDepth(DefaultSubjectDepth)` (where `DefaultSubjectDepth = 3`) by default, unless explicitly overridden
- **Backward compatibility**: Passing `MiddlewareSubjectMapper(nil)` explicitly restores pre-0.25 pass-through behavior (raw subjects)
- **Consistent label application**: Mapped subjects are computed once per message and threaded through `ackableWrapper`, ensuring ack/nak/term counters use the same normalized subject labels as processed/latency metrics

## Implementation Details

- Added `subjectMapperSet` sentinel field to `params` struct to distinguish between "not configured" (apply default) and "explicitly nil" (pass-through)
- Modified `ackableWrapper` to store the normalized subject and use it in all acknowledgment methods (`Ack`, `Nak`, `NackWithDelay`, `Term`, `TermWithReason`, `InProgress`)
- Comprehensive test coverage including edge cases (empty subjects, depth exceeding token count, negative depth) and integration tests verifying cardinality collapse and ack counter behavior
- Updated UPGRADING.md with migration guidance for users who need the previous behavior

## Breaking Change

The `subject` label values in metrics will change from raw subjects to truncated ones (first 3 tokens by default). Existing dashboards and alerts keyed on full subjects will need updates. This is documented in UPGRADING.md with clear migration paths.

https://claude.ai/code/session_01YYtUYNs98wYhGvtYuaS9kD