### PR TITLE
fix(transport)!: define SubscribeChan channel ownership (#28)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,17 @@ Each package implements a specific messaging pattern with full type safety:
 
 ### Notes
 
+#### SubscribeChan Channel Ownership (#28)
+
+- `transport.Conn.SubscribeChan`: peanats owns send side of caller's channel; sole sender, closes it on `Unsubscribe`
+- Caller must only receive, never close (double-close panics)
+- Internal `mirror` goroutine replaced: now reads NATS `nch`, mirrors to caller `ch`, selects on `quit`
+- `chanSubscriptionImpl.Unsubscribe`: NATS `Unsubscribe` first (stop delivery into nch), then `close(quit)` (once), then `<-done` (join goroutine, which closes ch via defer)
+- Inner `select { case ch <- ...; case <-quit }` lets teardown proceed even when caller stopped receiving (full buffer / blocked send)
+- Removed old `recover()`+drain hack that relied on send-on-closed panic; that was the data race + goroutine leak
+- `requester.responseReceiverImpl.Stop()` no longer `close(r.buf)`; Unsubscribe closes it
+- Breaking change documented in UPGRADING.md under v0.25.x → v0.26.0
+
 #### Prometheus Middleware Subject Cardinality Control (#25)
 
 - `contrib/prom` normalizes the `subject` label via a `SubjectMapper`
@@ -253,6 +264,7 @@ Each package implements a specific messaging pattern with full type safety:
 
 ### Changelog
 
+- 2026-06-01: transport: SubscribeChan defined channel ownership; Unsubscribe joins mirror goroutine and closes caller channel (breaking: callers must not close); fixes data race + goroutine leak (#28)
 - 2026-04-13: v0.25.0 — contrib/prom default subject mapper is now `SubjectDepth(3)` (breaking: restore with `MiddlewareSubjectMapper(nil)`); see UPGRADING.md (#25)
 - 2026-04-13: contrib/prom: `SubjectMapper` + `SubjectDepth`/`SubjectConstant` helpers to bound subject label cardinality (#25)
 - 2026-02-10: Content-Encoding compression layer: zstd + s2 support in codec, publisher, requester, bucket

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,49 @@
 # Upgrading
 
+## v0.25.x → v0.26.0
+
+### Summary
+
+`transport.Conn.SubscribeChan` now has a defined channel-ownership model.
+peanats owns the send side of the caller-supplied channel: it is the sole
+sender and it closes the channel on `Unsubscribe`. Callers must only receive
+from the channel and must **never** close it. `Unsubscribe` stops NATS
+delivery, joins the internal mirror goroutine, and then closes the channel
+(#28).
+
+Previously the channel had undefined teardown: the only implied way to stop
+the mirror goroutine was for the caller to close the channel, which raced the
+goroutine's send (flagged by `go test -race`) and leaked the goroutine on
+`Unsubscribe`. Both the data race and the goroutine leak are now fixed.
+
+### Action required
+
+If your code closed the channel returned/passed to `SubscribeChan`, remove the
+`close`. Closing it now double-closes (peanats already closes it) and panics.
+
+```go
+// Before — racy, and now panics:
+sub.Unsubscribe()
+close(ch)
+
+// After — peanats closes ch for you:
+sub.Unsubscribe()
+```
+
+Detect teardown by receiving the zero value with `ok == false`:
+
+```go
+for msg := range ch { // ranges until peanats closes ch on Unsubscribe
+    // ...
+}
+```
+
+The `requester` package already follows this model internally;
+`ResponseReceiver.Stop()` no longer closes its buffer and needs no change from
+callers.
+
+---
+
 ## v0.24.x → v0.25.0
 
 ### Summary

--- a/requester/requester.go
+++ b/requester/requester.go
@@ -293,6 +293,7 @@ func (r *responseReceiverImpl[T]) Next(ctx context.Context) (_ Response[T], err 
 }
 
 func (r *responseReceiverImpl[T]) Stop() error {
-	close(r.buf)
+	// Unsubscribe joins the transport mirror goroutine and closes r.buf; the
+	// receiver must not close it itself (that would race the mirror's send).
 	return r.sub.Unsubscribe()
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -3,6 +3,7 @@ package transport
 import (
 	"context"
 	"errors"
+	"sync"
 
 	"github.com/nats-io/nats.go"
 
@@ -26,6 +27,11 @@ type Conn interface {
 	Publish(ctx context.Context, msg peanats.Msg) error
 	Request(ctx context.Context, msg peanats.Msg) (peanats.Msg, error)
 	Subscribe(ctx context.Context, subj string, opts ...SubscribeOption) (Subscription, error)
+	// SubscribeChan delivers messages to the caller-supplied channel. peanats
+	// owns the send side of ch: the caller must only receive from it and must
+	// never close it. Calling Unsubscribe stops NATS delivery, joins the
+	// internal mirror goroutine, and then closes ch. The caller can detect
+	// teardown via a receive returning the zero value with ok == false.
 	SubscribeChan(ctx context.Context, subj string, ch chan peanats.Msg, opts ...SubscribeChanOption) (Unsubscriber, error)
 	SubscribeHandler(ctx context.Context, subj string, handler peanats.MsgHandler, opts ...SubscribeHandlerOption) (Unsubscriber, error)
 	Drain() error
@@ -180,22 +186,6 @@ func (c *connImpl) SubscribeHandler(ctx context.Context, subj string, h peanats.
 	}
 }
 
-func (c *connImpl) mirror(mch chan peanats.Msg) chan *nats.Msg {
-	nch := make(chan *nats.Msg, cap(mch))
-	go func() {
-		defer func() {
-			if recover() != nil {
-				for range nch {
-				}
-			}
-		}()
-		for msg := range nch {
-			mch <- peanats.NewMsg(msg)
-		}
-	}()
-	return nch
-}
-
 // SubscribeChanOption configures channel-based subscriptions.
 type SubscribeChanOption func(*subscribeChanParams)
 
@@ -215,19 +205,64 @@ func (c *connImpl) SubscribeChan(_ context.Context, subj string, ch chan peanats
 	for _, o := range opts {
 		o(&p)
 	}
+	// nch is the channel NATS delivers into; the mirror goroutine is its sole
+	// reader and ch's sole sender. This keeps ownership well-defined: NATS owns
+	// nch, peanats owns ch.
+	nch := make(chan *nats.Msg, cap(ch))
 	var (
 		sub *nats.Subscription
 		err error
 	)
 	if p.queue != "" {
-		sub, err = c.nc.ChanQueueSubscribe(subj, p.queue, c.mirror(ch))
+		sub, err = c.nc.ChanQueueSubscribe(subj, p.queue, nch)
 	} else {
-		sub, err = c.nc.ChanSubscribe(subj, c.mirror(ch))
+		sub, err = c.nc.ChanSubscribe(subj, nch)
 	}
 	if err != nil {
 		return nil, err
 	}
-	return &subscriptionImpl{sub}, nil
+	quit := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		// peanats is the sole sender on ch, so it closes it on teardown.
+		defer close(ch)
+		for {
+			select {
+			case <-quit:
+				return
+			case msg, ok := <-nch:
+				if !ok {
+					return
+				}
+				select {
+				case ch <- peanats.NewMsg(msg):
+				case <-quit:
+					return
+				}
+			}
+		}
+	}()
+	return &chanSubscriptionImpl{sub: sub, quit: quit, done: done}, nil
+}
+
+type chanSubscriptionImpl struct {
+	sub  *nats.Subscription
+	quit chan struct{}
+	done chan struct{}
+	once sync.Once
+}
+
+func (s *chanSubscriptionImpl) Unsubscribe() error {
+	// Stop NATS delivery first so nothing new lands in nch, then signal the
+	// mirror goroutine to stop and wait for it to drain and close the caller's
+	// channel.
+	err := s.sub.Unsubscribe()
+	s.once.Do(func() {
+		close(s.quit)
+	})
+	<-s.done
+	return err
 }
 
 type subscriptionImpl struct {

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -12,7 +12,11 @@ import (
 	"github.com/mikluko/peanats/transport"
 )
 
-func TestMirror_ClosedChannelRecovery(t *testing.T) {
+// TestSubscribeChan_UnsubscribeClosesChannel verifies the ownership model:
+// peanats owns the send side of the caller's channel and closes it on
+// Unsubscribe. The caller only ever receives. Run under -race to confirm no
+// data race between teardown and the mirror goroutine's send.
+func TestSubscribeChan_UnsubscribeClosesChannel(t *testing.T) {
 	srv := xtestutil.Server(t)
 	nc, err := nats.Connect(srv.ClientURL())
 	require.NoError(t, err)
@@ -22,11 +26,57 @@ func TestMirror_ClosedChannelRecovery(t *testing.T) {
 
 	ch := make(chan peanats.Msg, 1)
 
-	sub, err := conn.SubscribeChan(t.Context(), "test.mirror.panic", ch)
+	sub, err := conn.SubscribeChan(t.Context(), "test.subchan.close", ch)
 	require.NoError(t, err)
 
 	for range 10 {
-		err = nc.Publish("test.mirror.panic", []byte("test"))
+		err = nc.Publish("test.subchan.close", []byte("test"))
+		require.NoError(t, err)
+	}
+	err = nc.Flush()
+	require.NoError(t, err)
+
+	// Drain whatever has been delivered concurrently with teardown.
+	go func() {
+		for range ch { //nolint:revive // drain until closed
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	err = sub.Unsubscribe()
+	require.NoError(t, err)
+
+	// After Unsubscribe returns, the mirror goroutine has joined and ch is
+	// closed; a receive must observe the closed channel, not block.
+	select {
+	case _, ok := <-ch:
+		require.False(t, ok, "channel must be closed after Unsubscribe")
+	case <-time.After(time.Second):
+		t.Fatal("channel not closed after Unsubscribe")
+	}
+}
+
+// TestSubscribeChan_StopReceivingThenUnsubscribe verifies teardown works even
+// when the caller has stopped receiving (channel buffer full, mirror blocked
+// on send). Unsubscribe must still join the mirror goroutine without leaking.
+func TestSubscribeChan_StopReceivingThenUnsubscribe(t *testing.T) {
+	srv := xtestutil.Server(t)
+	nc, err := nats.Connect(srv.ClientURL())
+	require.NoError(t, err)
+	defer nc.Close()
+
+	conn := transport.New(nc)
+
+	// Unbuffered: the mirror goroutine blocks on send once one message is in
+	// flight and the caller is not receiving.
+	ch := make(chan peanats.Msg)
+
+	sub, err := conn.SubscribeChan(t.Context(), "test.subchan.block", ch)
+	require.NoError(t, err)
+
+	for range 5 {
+		err = nc.Publish("test.subchan.block", []byte("test"))
 		require.NoError(t, err)
 	}
 	err = nc.Flush()
@@ -34,10 +84,13 @@ func TestMirror_ClosedChannelRecovery(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	close(ch)
-
-	err = sub.Unsubscribe()
-	require.NoError(t, err)
-
-	time.Sleep(50 * time.Millisecond)
+	// Never received; Unsubscribe must still return promptly.
+	done := make(chan error, 1)
+	go func() { done <- sub.Unsubscribe() }()
+	select {
+	case err = <-done:
+		require.NoError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Unsubscribe blocked: mirror goroutine leaked")
+	}
 }


### PR DESCRIPTION
Fixes #28.

## Problem

`transport.Conn.SubscribeChan` had undefined channel ownership. The internal `mirror` goroutine was the send side of the caller's channel, but no safe join point was exposed:

- The implied teardown (caller closing the channel) **races** the mirror's send. `go test -race` flags `close(ch)` vs `ch <- ...`. The old `recover()`+drain swallowed the panic but not the race.
- `Unsubscribe()` stopped NATS delivery but never stopped the mirror goroutine, which then blocked forever on `for range nch` — a goroutine leak.

The bug also affected `requester`, whose `ResponseReceiver.Stop()` did exactly the racy `close(buf)` + `Unsubscribe()`.

## Fix

Give `SubscribeChan` a defined ownership model: **peanats owns the send side** of the caller's channel.

- The mirror goroutine is the sole sender on the caller's channel and the sole reader of the NATS-owned `nch`.
- `Unsubscribe()` stops NATS delivery first, signals the goroutine via a `quit` channel, joins it (`<-done`), and the goroutine closes the caller's channel on exit.
- An inner `select { case ch <- ...; case <-quit }` lets teardown proceed even when the caller has stopped receiving (full buffer / blocked send).
- The `recover()`+drain hack is gone.

Callers now only ever receive and detect teardown via a closed-channel receive (`ok == false`).

`requester.ResponseReceiver.Stop()` no longer closes its buffer; `Unsubscribe` does.

## Breaking change

Callers must no longer close the channel themselves (peanats closes it; double-close panics). Documented in `UPGRADING.md` under v0.25.x -> v0.26.0.

## Tests

- Rewrote the transport test to assert the new semantics (channel closed after Unsubscribe; no leak when caller stopped receiving).
- Full suite passes under `go test -race ./...`.
